### PR TITLE
fix(output): filter out null results when json output requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,9 +63,10 @@ types.forEach(type => {
 Promise
   .all(dependencies.map(check))
   .then(output => {
+
     // JSON
     if (process.args.json) {
-      console.log(JSON.stringify(output))
+      console.log(JSON.stringify(output.filter(result => !!result)))
       process.exit(1)
     }
 

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ Promise
 
     // JSON
     if (process.args.json) {
-      console.log(JSON.stringify(output.filter(result => !!result)))
+      console.log(JSON.stringify(output.filter(Boolean)))
       process.exit(1)
     }
 


### PR DESCRIPTION
Running the package with the `--json` flag right now doesn't filter out the packages that did not need updates, hence the array that gets stringified will have a bunch of `null` entries in there.

For example:

```sh
npx updated --json

[null,null,null,null,null,null,null,null,null,null,null,{"status":"outdated","name":"eslint-config-airbnb","version":"^17.0.0","oldest":"17.0.0","latest":"17.1.0"},{"status":"outdated","name":"eslint-plugin-import","version":"^2.13.0","oldest":"2.13.0","latest":"2.14.0"},null,null,null,null,null]
```

This PR filters out the null entries for JSON output, so that it looks like this:

```sh
npx updated --json

[{"status":"outdated","name":"eslint-config-airbnb","version":"^17.0.0","oldest":"17.0.0","latest":"17.1.0"},{"status":"outdated","name":"eslint-plugin-import","version":"^2.13.0","oldest":"2.13.0","latest":"2.14.0"}]
```